### PR TITLE
refactor: Add `InspectorView`

### DIFF
--- a/RsyncUI/Views/InspectorViews/AddFirstTask.swift
+++ b/RsyncUI/Views/InspectorViews/AddFirstTask.swift
@@ -9,8 +9,6 @@ import SwiftUI
 
 struct AddFirstTask: View {
     @Bindable var rsyncUIdata: RsyncUIconfigurations
-    @Binding var addFirstTask: Bool
-
     @State var newdata = ObservableAddConfigurations()
 
     var body: some View {
@@ -35,7 +33,6 @@ struct AddFirstTask: View {
                                        text: "Add",
                                        helpText: "Add task") {
                     addConfig()
-                    addFirstTask = false
                 }
             }
         }

--- a/RsyncUI/Views/InspectorViews/EditTabView.swift
+++ b/RsyncUI/Views/InspectorViews/EditTabView.swift
@@ -7,27 +7,47 @@
 
 import SwiftUI
 
-enum InspectorTab: Hashable {
-    case edit
-    case parameters
-    case logview
-    case verifytask
-}
-
 struct EditTabView: View {
     @Bindable var rsyncUIdata: RsyncUIconfigurations
-    @State private var selectedTab: InspectorTab = .edit
     @State private var selecteduuids = Set<SynchronizeConfiguration.ID>()
-    @State private var addFirstTask: Bool = false
-    // Show Inspector view, if true shwo inspectors by default on both views
-
+    @State private var hasTasks: Bool = false
+    
     var body: some View {
         HStack(alignment: .top, spacing: 0) {
-            if addFirstTask {
-                AddFirstTask(
-                    rsyncUIdata: rsyncUIdata,
-                    addFirstTask: $addFirstTask
-                )
+            if !hasTasks {
+                VStack {
+                    AddFirstTask(rsyncUIdata: rsyncUIdata)
+                    
+                    VStack(alignment: .leading, spacing: 12) {
+                        Text("For your own safety, please read the user doc\n")
+                        + Text("Getting Started").bold()
+                        + Text(", ")
+                        + Text("Important").bold()
+                        + Text(" about the ")
+                        + Text("--delete").font(.system(.body, design: .monospaced))
+                        + Text(" parameter.\n")
+                        
+                        Text("The ")
+                        + Text("--delete").font(.system(.body, design: .monospaced))
+                        + Text(" parameter is disabled by default.\n")
+                        
+                        Text("If Synchronize ID is ")
+                        + Text("blue").foregroundColor(.blue)
+                        + Text(" the parameter is disabled.\n")
+                        
+                        Text("If the Synchronize ID is ")
+                        + Text("red").foregroundColor(.red)
+                        + Text(" parameter is enabled.")
+                    }
+                    .padding()
+                    .font(.title2)
+                    /*
+                     Text(important)
+                     .font(.title2)
+                     .padding()
+                     */
+                }
+                
             } else {
                 // Shared task list table on the left
                 ListofTasksAddView(
@@ -51,101 +71,23 @@ struct EditTabView: View {
             }
         }
         .onAppear {
-            // No tasks added, must show the Add button
-            if rsyncUIdata.configurations == nil {
-                addFirstTask = true
-            }
-            if let config = rsyncUIdata.configurations {
-                if config.count == 0 {
-                    addFirstTask = true
-                }
-            }
+            updateAddFirstTask()
         }
-        .inspector(isPresented: .constant(true)) {
-            if addFirstTask {
-                VStack(alignment: .leading, spacing: 12) {
-                        Text("There is no task added, please add task using the form.\n")
-                        
-                        Text("For your own safety, please read the user doc\n")
-                        + Text("Getting Started").bold()
-                        + Text(", ")
-                        + Text("Important").bold()
-                        + Text(" about the ")
-                        + Text("--delete").font(.system(.body, design: .monospaced))
-                        + Text(" parameter.\n")
-                        
-                        Text("The ")
-                        + Text("--delete").font(.system(.body, design: .monospaced))
-                        + Text(" parameter is disabled by default.\n")
-                        
-                        Text("If Synchronize ID is ")
-                        + Text("blue").foregroundColor(.blue)
-                        + Text(" the parameter is disabled.\n")
-                        
-                        Text("If the Synchronize ID is ")
-                        + Text("red").foregroundColor(.red)
-                        + Text(" parameter is enabled.")
-                    }
-                    .padding()
-                    .font(.title2)
-                /*
-                Text(important)
-                    .font(.title2)
-                    .padding()
-                 */
-            } else if selecteduuids.count == 0 {
-                Text("No task\nselected")
-                    .font(.title2)
-            } else {
-                // Tab-specific inspector views on the right
-                TabView(selection: $selectedTab) {
-                    AddTaskView(rsyncUIdata: rsyncUIdata,
-                                selectedTab: $selectedTab,
-                                selecteduuids: $selecteduuids)
-                        .tabItem {
-                            Label("Edit", systemImage: "plus.circle")
-                        }
-                        .tag(InspectorTab.edit)
-                        .id(InspectorTab.edit)
+        .onChange(of: rsyncUIdata.configurations?.count) { oldValue, newValue in
+            updateAddFirstTask()
+        }
+        .inspector(isPresented: .constant(hasTasks)) {
+            InspectorView(rsyncUIdata: rsyncUIdata, selecteduuids: $selecteduuids)
+        }
 
-                    RsyncParametersView(rsyncUIdata: rsyncUIdata,
-                                        selectedTab: $selectedTab,
-                                        selecteduuids: $selecteduuids)
-                        .tabItem {
-                            Label("Parameters", systemImage: "slider.horizontal.3")
-                        }
-                        .tag(InspectorTab.parameters)
-                        .id(InspectorTab.parameters)
-
-                    LogRecordsTabView(
-                        rsyncUIdata: rsyncUIdata,
-                        selectedTab: $selectedTab,
-                        selecteduuids: $selecteduuids
-                    )
-                    .tabItem {
-                        Label("Log Records", systemImage: "slider.horizontal.3")
-                    }
-                    .tag(InspectorTab.logview)
-                    .id(InspectorTab.logview)
-
-                    VerifyTaskTabView(
-                        rsyncUIdata: rsyncUIdata,
-                        selectedTab: $selectedTab,
-                        selecteduuids: $selecteduuids
-                    )
-                    .tabItem {
-                        Label("Verify Task", systemImage: "slider.horizontal.3")
-                    }
-                    .tag(InspectorTab.verifytask)
-                    .id(InspectorTab.verifytask)
-                }
-                .padding()
-                .navigationTitle("")
-                .inspectorColumnWidth(min: 550, ideal: 600, max: 650)
-            }
+    }
+    func updateAddFirstTask() {
+        if let config = rsyncUIdata.configurations {
+            hasTasks = !config.isEmpty
+        } else {
+            hasTasks = false
         }
     }
-    
     let important = """
         There is no task added please add task using the form.
         

--- a/RsyncUI/Views/InspectorViews/InspectorView.swift
+++ b/RsyncUI/Views/InspectorViews/InspectorView.swift
@@ -1,0 +1,78 @@
+
+//
+//  EditTabView.swift
+//  RsyncUI
+//
+//  Created by Thomas Evensen on 28/12/2025.
+//
+
+import SwiftUI
+
+enum InspectorTab: Hashable {
+    case edit
+    case parameters
+    case logview
+    case verifytask
+}
+
+struct InspectorView: View {
+    @Bindable var rsyncUIdata: RsyncUIconfigurations
+    @Binding var selecteduuids: Set<SynchronizeConfiguration.ID>
+    
+    @State private var selectedTab: InspectorTab = .edit
+    
+    var body: some View {
+        if selecteduuids.count == 0 {
+            Text("No task\nselected")
+                .font(.title2)
+        } else {
+            // Tab-specific inspector views on the right
+            TabView(selection: $selectedTab) {
+                AddTaskView(rsyncUIdata: rsyncUIdata,
+                            selectedTab: $selectedTab,
+                            selecteduuids: $selecteduuids)
+                .tabItem {
+                    Label("Edit", systemImage: "plus.circle")
+                }
+                .tag(InspectorTab.edit)
+                .id(InspectorTab.edit)
+                
+                RsyncParametersView(rsyncUIdata: rsyncUIdata,
+                                    selectedTab: $selectedTab,
+                                    selecteduuids: $selecteduuids)
+                .tabItem {
+                    Label("Parameters", systemImage: "slider.horizontal.3")
+                }
+                .tag(InspectorTab.parameters)
+                .id(InspectorTab.parameters)
+                
+                LogRecordsTabView(
+                    rsyncUIdata: rsyncUIdata,
+                    selectedTab: $selectedTab,
+                    selecteduuids: $selecteduuids
+                )
+                .tabItem {
+                    Label("Log Records", systemImage: "slider.horizontal.3")
+                }
+                .tag(InspectorTab.logview)
+                .id(InspectorTab.logview)
+                
+                VerifyTaskTabView(
+                    rsyncUIdata: rsyncUIdata,
+                    selectedTab: $selectedTab,
+                    selecteduuids: $selecteduuids
+                )
+                .tabItem {
+                    Label("Verify Task", systemImage: "slider.horizontal.3")
+                }
+                .tag(InspectorTab.verifytask)
+                .id(InspectorTab.verifytask)
+            }
+            .padding()
+            .navigationTitle("")
+            .inspectorColumnWidth(min: 550, ideal: 600, max: 650)
+        }
+        
+    }
+    
+}


### PR DESCRIPTION
This PR cleans up EditTabView by introducing `InspectorView`.
Other changes include:
- add `.onChange()` to observe tasks: This fixes a bug where no form was shown when deleting all tasks
- move `--delete` parameter messages from the inspector to the detail view under the `AddFirstTask` view. This allows to hide the inspector if no tasks exist and the form shows up.

