### PR TITLE
Replace buttons with `ToolbarItem` buttons in sheets

### DIFF
--- a/RsyncUI/Views/InspectorViews/Add/extensionAddTaskView+ViewBuilders.swift
+++ b/RsyncUI/Views/InspectorViews/Add/extensionAddTaskView+ViewBuilders.swift
@@ -23,7 +23,8 @@ extension AddTaskView {
 
     var addTaskSheetView: some View {
         VStack {
-            Text("Add Task").font(.title2)
+            Text("Add Task")
+                .font(.title2)
 
             VStack(alignment: .leading, spacing: 12) {
 

--- a/RsyncUI/Views/InspectorViews/Add/extensionAddTaskView+ViewBuilders.swift
+++ b/RsyncUI/Views/InspectorViews/Add/extensionAddTaskView+ViewBuilders.swift
@@ -22,51 +22,40 @@ extension AddTaskView {
     }
 
     var addTaskSheetView: some View {
-        VStack(alignment: .leading, spacing: 12) {
-            Text("Add Task").font(.headline)
+        VStack {
+            Text("Add Task").font(.title2)
 
-            HStack {
-                pickerselecttypeoftask
-                trailingslash
+            VStack(alignment: .leading, spacing: 12) {
+
+                HStack {
+                    pickerselecttypeoftask
+                    trailingslash
+                }
+
+                synchronizeID
+                catalogSectionView
+                remoteuserandserver
             }
-
-            synchronizeID
-            catalogSectionView
-            remoteuserandserver
-
-            HStack {
-                ConditionalGlassButton(systemImage: "plus",
-                                       text: "Add",
-                                       helpText: "Add task") {
+        }
+        .padding()
+        .frame(minWidth: 600)
+        .onSubmit { handleSubmit() }
+        .toolbar {
+            ToolbarItem(placement: .confirmationAction) {
+                Button("Add") {
                     Task { @MainActor in
                         if await addConfig() {
                             showAddPopover = false
                         }
                     }
                 }
+            }
 
-                Spacer()
-
-                if #available(macOS 26.0, *) {
-                    Button("Close", role: .close) {
-                        showAddPopover = false
-                    }
-                    .buttonStyle(RefinedGlassButtonStyle())
-                    .keyboardShortcut(.cancelAction)
-                } else {
-                    Button {
-                        showAddPopover = false
-                    } label: {
-                        Label("Close", systemImage: "return")
-                            .labelStyle(.iconOnly)
-                    }
-                    .help("Close")
-                    .keyboardShortcut(.cancelAction)
+            ToolbarItem(placement: .cancellationAction) {
+                Button("Cancel") {
+                    showAddPopover = false
                 }
             }
         }
-        .padding()
-        .frame(minWidth: 600)
-        .onSubmit { handleSubmit() }
     }
 }

--- a/RsyncUI/Views/Profiles/ProfileView.swift
+++ b/RsyncUI/Views/Profiles/ProfileView.swift
@@ -123,8 +123,8 @@ struct AddProfileSheet: View {
 
     var body: some View {
         VStack(spacing: 20) {
-            Text("Add New Profile")
-                .font(.headline)
+            Text("Add Profile")
+                .font(.title2)
 
             TextField("Profile Name", text: $profileName)
                 .textFieldStyle(.roundedBorder)

--- a/RsyncUI/Views/Profiles/ProfileView.swift
+++ b/RsyncUI/Views/Profiles/ProfileView.swift
@@ -135,23 +135,23 @@ struct AddProfileSheet: View {
                     .foregroundStyle(.red)
                     .font(.caption)
             }
-
-            HStack(spacing: 12) {
-                ConditionalGlassButton(systemImage: "plus",
-                                       text: "Add",
-                                       helpText: "Create profile") {
-                    addProfile()
-                    showSheet = false
-                }
-
-                Button("Cancel") {
-                    showSheet = false
-                }
-                .keyboardShortcut(.cancelAction)
-            }
         }
         .padding(24)
         .frame(width: 400)
+        .toolbar {
+            ToolbarItem(placement: .confirmationAction) {
+                Button("Add") {
+                    addProfile()
+                    showSheet = false
+                }
+            }
+
+            ToolbarItem(placement: .cancellationAction) {
+                Button("Cancel") {
+                    showSheet = false
+                }
+            }
+        }
     }
 
     private func addProfile() {


### PR DESCRIPTION
This PR replaces add/cancel buttons in `AddTaskView` and `ProfileView` with `ToolbarItem`s containing buttons.
They also have https://developer.apple.com/documentation/swiftui/toolbaritemplacement/confirmationaction and https://developer.apple.com/documentation/swiftui/toolbaritemplacement/cancellationaction for sensible default behaviours.
<img width="1644" height="1048" alt="Bildschirmfoto 2026-07-06 um 11 52 14" src="https://github.com/user-attachments/assets/6ea9951c-c5e5-4806-be7b-4e644f9387b9" />
<img width="1644" height="1048" alt="Bildschirmfoto 2026-07-06 um 11 52 33" src="https://github.com/user-attachments/assets/ec9b3733-be14-44ba-a616-d712ca7becff" />
