### PR TITLE
add `role: .destructive` to delete buttons

### DIFF
--- a/RsyncUI/Views/Configurations/ListofTasksAddView.swift
+++ b/RsyncUI/Views/Configurations/ListofTasksAddView.swift
@@ -21,7 +21,7 @@ struct ListofTasksAddView: View {
             .confirmationDialog(selecteduuids.count == 1 ? "Delete 1 configuration" :
                 "Delete \(selecteduuids.count) configurations",
                 isPresented: $confirmdelete) {
-                    Button("Delete") {
+                Button("Delete", role: .destructive) {
                         delete()
                         confirmdelete = false
                     }

--- a/RsyncUI/Views/Configurations/ListofTasksMainView.swift
+++ b/RsyncUI/Views/Configurations/ListofTasksMainView.swift
@@ -44,7 +44,7 @@ struct ListofTasksMainView: View {
             .confirmationDialog(selecteduuids.count == 1 ? "Delete 1 configuration" :
                 "Delete \(selecteduuids.count) configurations",
                 isPresented: $confirmdelete) {
-                    Button("Delete") {
+                Button("Delete", role: .destructive) {
                         delete()
                         confirmdelete = false
                     }

--- a/RsyncUI/Views/ScheduleView/CalendarMonthView.swift
+++ b/RsyncUI/Views/ScheduleView/CalendarMonthView.swift
@@ -60,7 +60,7 @@ struct CalendarMonthView: View {
                         .confirmationDialog(selecteduuids.count == 1 ? "Delete 1 schedule" :
                             "Delete \(selecteduuids.count) schedules",
                             isPresented: $confirmdelete) {
-                                Button("Delete") {
+                                Button("Delete", role: .destructive) {
                                     schedules.delete(selecteduuids)
 
                                     date = Date.now
@@ -96,7 +96,7 @@ struct CalendarMonthView: View {
                             .confirmationDialog(selecteduuidsnotexecuted.count == 1 ? "Delete 1 schedule" :
                                 "Delete \(selecteduuidsnotexecuted.count) schedules",
                                 isPresented: $confirmdeletenotexecuted) {
-                                    Button("Delete") {
+                                    Button("Delete", role: .destructive) {
                                         schedules.deletenotexecuted(selecteduuidsnotexecuted)
                                         selecteduuidsnotexecuted.removeAll()
                                     }

--- a/RsyncUI/Views/Snapshots/SnapshotListView.swift
+++ b/RsyncUI/Views/Snapshots/SnapshotListView.swift
@@ -52,7 +52,7 @@ struct SnapshotListView: View {
         .confirmationDialog(snapshotdata.snapshotuuidsfordelete.count == 1 ? "Delete 1 snapshot" :
             "Delete \(snapshotdata.snapshotuuidsfordelete.count) snapshots",
             isPresented: $confirmdelete) {
-                Button("Delete") {
+                Button("Delete", role: .destructive) {
                     delete()
                     confirmdelete = false
                 }


### PR DESCRIPTION
This PR adds missing `role: .destructive` to confirmation dialog delete buttons.