### PR TITLE
Move `AboutView` close button into sheet

### DIFF
--- a/RsyncUI/Main/RsyncUIApp.swift
+++ b/RsyncUI/Main/RsyncUIApp.swift
@@ -23,7 +23,22 @@ struct RsyncUIApp: App {
                     Homepath().createRootProfileCatalog()
                 }
                 .frame(minWidth: 1100, idealWidth: 1300, minHeight: 580)
-                .sheet(isPresented: $showabout) { AboutView() }
+                .sheet(isPresented: $showabout) {
+                    AboutView()
+                        .toolbar {
+                            ToolbarItem(placement: .cancellationAction) {
+                                if #available(macOS 26.0, *) {
+                                    Button("Close", role: .close) {
+                                        showabout = false
+                                    }
+                                } else {
+                                    Button("Close") {
+                                        showabout = false
+                                    }
+                                }
+                            }
+                        }
+                }
                 .onDisappear {
                     // Quit the app when the main window is closed
                     performCleanupTask()

--- a/RsyncUI/Views/Settings/AboutView.swift
+++ b/RsyncUI/Views/Settings/AboutView.swift
@@ -8,8 +8,6 @@
 import SwiftUI
 
 struct AboutView: View {
-    @Environment(\.dismiss) var dismiss
-
     @State private var urlstring = ""
 
     var changelog: String {
@@ -66,7 +64,6 @@ struct AboutView: View {
                         helpText: "Changelog"
                     ) {
                         openChangelog()
-                        dismiss()
                     }
 
                     if SharedReference.shared.newversion {
@@ -77,20 +74,6 @@ struct AboutView: View {
                         ) {
                             openDownload()
                         }
-                    }
-
-                    Spacer()
-
-                    if #available(macOS 26.0, *) {
-                        Button("Close", role: .close) {
-                            dismiss()
-                        }
-                        .buttonStyle(RefinedGlassButtonStyle())
-                    } else {
-                        Button("Close") {
-                            dismiss()
-                        }
-                        .buttonStyle(.borderedProminent)
                     }
                 }
             } header: {


### PR DESCRIPTION
This PR moves the close button out of `AboutView` and into the sheet toolbar as a `ToolbarItem`.
This is for two reasons:
1. A close button in the About section of `settings` doesn't make sense.
2. `About RsyncUI` opens a sheet but the close button should not be part of the `AboutView`.

Before

<img width="1012" height="744" alt="Bildschirmfoto 2026-07-07 um 18 55 02" src="https://github.com/user-attachments/assets/45c41194-c13b-4c49-8924-71a5902f2292" />
<img width="1644" height="1050" alt="Bildschirmfoto 2026-07-07 um 18 59 26" src="https://github.com/user-attachments/assets/8495e346-b582-4215-b5d3-4a8b1d513b32" />

After
<img width="1012" height="744" alt="Bildschirmfoto 2026-07-07 um 18 55 34" src="https://github.com/user-attachments/assets/5666dc75-bfdd-4a6c-b2ba-28cea63636dd" />

<img width="1644" height="1050" alt="Bildschirmfoto 2026-07-07 um 18 55 23" src="https://github.com/user-attachments/assets/92d8e7d6-844e-4f47-8ce4-c7d3605ff464" />

