### PR TITLE
Remove inspector tab label

### DIFF
--- a/RsyncUI/Views/InspectorViews/InspectorView.swift
+++ b/RsyncUI/Views/InspectorViews/InspectorView.swift
@@ -42,6 +42,7 @@ struct InspectorView: View {
                     Text("Logs").tag(InspectorTab.logview)
                     Text("Verify").tag(InspectorTab.verifytask)
                 }
+                .labelsHidden()
                 .pickerStyle(.segmented)
                 .padding(.horizontal, 12)
                 .padding(.vertical, 8)


### PR DESCRIPTION
This PR removes the `Inspector Tab` label.

Before
<img width="1599" height="863" alt="Bildschirmfoto 2026-07-08 um 08 37 40" src="https://github.com/user-attachments/assets/8dbcc02c-867b-4e71-8871-d5577171f4e2" />

After
<img width="1599" height="863" alt="Bildschirmfoto 2026-07-08 um 08 36 35" src="https://github.com/user-attachments/assets/a82ecf60-a4d3-4cc6-9656-04e2f09bd2b9" />
