### PR TITLE
Rename `TasksView` to `SynchronizeTasksView`

### DIFF
--- a/RsyncUI/Views/Tasks/SidebarTasksView.swift
+++ b/RsyncUI/Views/Tasks/SidebarTasksView.swift
@@ -41,7 +41,7 @@ struct SidebarTasksView: View {
 
     var body: some View {
         NavigationStack(path: $executetaskpath) {
-            TasksView(rsyncUIdata: rsyncUIdata,
+            SynchronizeTasksView(rsyncUIdata: rsyncUIdata,
                       progressdetails: progressdetails,
                       schedules: schedules,
                       selecteduuids: $selecteduuids,

--- a/RsyncUI/Views/Tasks/SynchronizeTasksView.swift
+++ b/RsyncUI/Views/Tasks/SynchronizeTasksView.swift
@@ -1,5 +1,5 @@
 //
-//  TasksView.swift
+//  SynchronizeTasksView.swift
 //  RsyncUI
 //
 //  Created by Thomas Evensen on 10/11/2023.
@@ -28,7 +28,7 @@ struct CopyItem: Identifiable, Codable, Transferable {
     }
 }
 
-struct TasksView: View {
+struct SynchronizeTasksView: View {
     @Environment(\.openWindow) var openWindow
 
     @Bindable var rsyncUIdata: RsyncUIconfigurations
@@ -141,7 +141,7 @@ struct TasksView: View {
     }
 }
 
-extension TasksView {
+extension SynchronizeTasksView {
     func handleSelectedUuidsChange() {
         if let configurations = rsyncUIdata.configurations {
             if let index = configurations.firstIndex(where: { $0.id == selecteduuids.first }) {

--- a/RsyncUI/Views/Tasks/extensionTasksView.swift
+++ b/RsyncUI/Views/Tasks/extensionTasksView.swift
@@ -9,7 +9,7 @@ import Observation
 import OSLog
 import SwiftUI
 
-extension TasksView {
+extension SynchronizeTasksView {
     @ToolbarContentBuilder
     var taskviewtoolbarcontent: some ToolbarContent {
         ToolbarItem {


### PR DESCRIPTION
This PR renames `TasksView` to `SynchronizeTasksView` as `TasksView` should be reserved for the view that is displayed by selecting `Tasks` in the sidebar.