### PR TITLE
Separate `ObservableAddConfigurations` in add and update logic

### DIFF
--- a/RsyncUI/Views/InspectorViews/Add/AddTaskSheetView.swift
+++ b/RsyncUI/Views/InspectorViews/Add/AddTaskSheetView.swift
@@ -10,28 +10,27 @@ import SwiftUI
 struct AddTaskSheetView: View {
     @Environment(\.dismiss) var dismiss
     
-    @Binding var newdata: ObservableAddConfigurations
-    @Binding var selectedconfig: SynchronizeConfiguration?
+    @State var newdata = ObservableAddConfigurations()
     @Binding var changesnapshotnum: Bool
     @Binding var stringestimate: String
 
     @Binding var presentglobaltaskview: Bool
 
-    var onAdd: () -> Void
+    var onAdd: (ObservableAddConfigurations) -> Void
 
         var body: some View {
             VStack {
                 Text("Add Task")
                     .font(.title2)
 
-                TaskForm(mode: .add, newdata: $newdata, selectedconfig: $selectedconfig, changesnapshotnum: $changesnapshotnum, stringestimate: $stringestimate)
+                TaskForm(mode: .add, newdata: $newdata, selectedconfig: .constant(nil), changesnapshotnum: $changesnapshotnum, stringestimate: $stringestimate)
             }
             .padding()
             .frame(minWidth: 600)
             .toolbar {
                 ToolbarItem(placement: .confirmationAction) {
                     Button("Add") {
-                        onAdd()
+                        onAdd(newdata)
                     }
                 }
 

--- a/RsyncUI/Views/InspectorViews/Add/AddTaskView.swift
+++ b/RsyncUI/Views/InspectorViews/Add/AddTaskView.swift
@@ -46,9 +46,9 @@ struct AddTaskView: View {
 
     @State var presentglobaltaskview: Bool = false
 
-    func onAdd() {
+    func onAdd(newdata: ObservableAddConfigurations) {
         Task { @MainActor in
-            if await addConfig() {
+            if await addConfig(newdata: newdata) {
                 showAddPopover = false
             }
         }
@@ -67,12 +67,6 @@ struct AddTaskView: View {
         .onSubmit { handleSubmit() }
         .onChange(of: rsyncUIdata.profile) { handleProfileChange() }
         .onChange(of: selecteduuids) { handleSelectionChange() }
-        .onChange(of: showAddPopover) { _, isPresented in
-            if isPresented {
-                newdata.resetForm()
-                selectedconfig = nil
-            }
-        }
-        .sheet(isPresented: $showAddPopover) { AddTaskSheetView(newdata: $newdata, selectedconfig: $selectedconfig, changesnapshotnum: $changesnapshotnum, stringestimate: $stringestimate, presentglobaltaskview: $presentglobaltaskview, onAdd: onAdd) }
+        .sheet(isPresented: $showAddPopover) { AddTaskSheetView(changesnapshotnum: $changesnapshotnum, stringestimate: $stringestimate, presentglobaltaskview: $presentglobaltaskview, onAdd: onAdd) }
     }
 }

--- a/RsyncUI/Views/InspectorViews/Add/extensionAddTaskView+BusinessLogic.swift
+++ b/RsyncUI/Views/InspectorViews/Add/extensionAddTaskView+BusinessLogic.swift
@@ -32,7 +32,7 @@ extension AddTaskView {
         case .remoteserverField:
             if newdata.selectedconfig == nil {
                 Task { @MainActor in
-                    _ = await addConfig()
+                    _ = await addConfig(newdata: newdata)
                 }
             } else {
                 Task { @MainActor in

--- a/RsyncUI/Views/InspectorViews/Add/extensionAddTaskView.swift
+++ b/RsyncUI/Views/InspectorViews/Add/extensionAddTaskView.swift
@@ -11,7 +11,7 @@ import SwiftUI
 
 extension AddTaskView {
     @MainActor
-    func addConfig() async -> Bool {
+    func addConfig(newdata: ObservableAddConfigurations) async -> Bool {
         let profile = rsyncUIdata.profile
         let beforeCount = rsyncUIdata.configurations?.count ?? 0
         rsyncUIdata.configurations = await newdata.addConfig(profile, rsyncUIdata.configurations)


### PR DESCRIPTION
This PR separates `ObservableAddConfigurations` between the add and update logic.
This fixes a bug where the inspector task form displayed the new task values: 

Before 
<img width="1645" height="1050" alt="Bildschirmfoto 2026-07-13 um 22 14 26" src="https://github.com/user-attachments/assets/f3f62c85-35ed-4def-be8d-cdbc52354904" />

After
<img width="1645" height="1050" alt="Bildschirmfoto 2026-07-13 um 22 11 39" src="https://github.com/user-attachments/assets/95ea1a72-d3eb-4291-97f5-63a54352539c" />
