### PR TITLE
Cleanup `TaskForm` bindings

### DIFF
--- a/RsyncUI/Views/InspectorViews/Add/AddTaskSheetView.swift
+++ b/RsyncUI/Views/InspectorViews/Add/AddTaskSheetView.swift
@@ -11,8 +11,6 @@ struct AddTaskSheetView: View {
     @Environment(\.dismiss) var dismiss
     
     @State var newdata = ObservableAddConfigurations()
-    @Binding var changesnapshotnum: Bool
-    @Binding var stringestimate: String
 
     var onAdd: (ObservableAddConfigurations) -> Void
 
@@ -21,7 +19,7 @@ struct AddTaskSheetView: View {
                 Text("Add Task")
                     .font(.title2)
 
-                TaskForm(mode: .add, newdata: $newdata, selectedconfig: .constant(nil), changesnapshotnum: $changesnapshotnum, stringestimate: $stringestimate)
+                TaskForm(newdata: $newdata)
             }
             .padding()
             .frame(minWidth: 600)

--- a/RsyncUI/Views/InspectorViews/Add/AddTaskView.swift
+++ b/RsyncUI/Views/InspectorViews/Add/AddTaskView.swift
@@ -33,13 +33,11 @@ enum TypeofTask: String, CaseIterable, Identifiable, CustomStringConvertible {
 
 struct AddTaskView: View {
     @Bindable var rsyncUIdata: RsyncUIconfigurations
-    @Binding var selectedTab: InspectorTab
     @Binding var selecteduuids: Set<SynchronizeConfiguration.ID>
 
     @FocusState var focusField: AddConfigurationField?
 
     @State var newdata = ObservableAddConfigurations()
-    @State var selectedconfig: SynchronizeConfiguration?
     @State var changesnapshotnum: Bool = false
     @State var stringestimate: String = ""
     @Binding var showAddPopover: Bool

--- a/RsyncUI/Views/InspectorViews/Add/AddTaskView.swift
+++ b/RsyncUI/Views/InspectorViews/Add/AddTaskView.swift
@@ -38,7 +38,6 @@ struct AddTaskView: View {
     @FocusState var focusField: AddConfigurationField?
 
     @State var newdata = ObservableAddConfigurations()
-    @State var changesnapshotnum: Bool = false
     @State var stringestimate: String = ""
     @Binding var showAddPopover: Bool
 
@@ -57,7 +56,7 @@ struct AddTaskView: View {
     }
 
     var body: some View {
-        TaskForm(focusField: _focusField, newdata: $newdata, changesnapshotnum: $changesnapshotnum, stringestimate: $stringestimate, onUpdate: onUpdate)
+        TaskForm(focusField: _focusField, newdata: $newdata, stringestimate: $stringestimate, onUpdate: onUpdate)
         .padding()
         .onAppear { handleSelectionChange() }
         .onSubmit { handleSubmit() }

--- a/RsyncUI/Views/InspectorViews/Add/AddTaskView.swift
+++ b/RsyncUI/Views/InspectorViews/Add/AddTaskView.swift
@@ -44,8 +44,6 @@ struct AddTaskView: View {
     @State var stringestimate: String = ""
     @Binding var showAddPopover: Bool
 
-    @State var presentglobaltaskview: Bool = false
-
     func onAdd(newdata: ObservableAddConfigurations) {
         Task { @MainActor in
             if await addConfig(newdata: newdata) {
@@ -61,12 +59,12 @@ struct AddTaskView: View {
     }
 
     var body: some View {
-        TaskForm(mode: .update, newdata: $newdata, selectedconfig: $selectedconfig, changesnapshotnum: $changesnapshotnum, stringestimate: $stringestimate, onUpdate: onUpdate)
+        TaskForm(focusField: _focusField, newdata: $newdata, changesnapshotnum: $changesnapshotnum, stringestimate: $stringestimate, onUpdate: onUpdate)
         .padding()
         .onAppear { handleSelectionChange() }
         .onSubmit { handleSubmit() }
         .onChange(of: rsyncUIdata.profile) { handleProfileChange() }
         .onChange(of: selecteduuids) { handleSelectionChange() }
-        .sheet(isPresented: $showAddPopover) { AddTaskSheetView(changesnapshotnum: $changesnapshotnum, stringestimate: $stringestimate, onAdd: onAdd) }
+        .sheet(isPresented: $showAddPopover) { AddTaskSheetView(onAdd: onAdd) }
     }
 }

--- a/RsyncUI/Views/InspectorViews/Add/TaskForm.swift
+++ b/RsyncUI/Views/InspectorViews/Add/TaskForm.swift
@@ -7,22 +7,44 @@
 import OSLog
 import SwiftUI
 
-enum TaskFormMode {
+private enum TaskFormMode {
     case add
     case update
 }
 
 struct TaskForm: View {
-    let mode: TaskFormMode
+    private let mode: TaskFormMode
 
     @FocusState var focusField: AddConfigurationField?
 
     @Binding var newdata: ObservableAddConfigurations
-    @Binding var selectedconfig: SynchronizeConfiguration?
     @Binding var changesnapshotnum: Bool
     @Binding var stringestimate: String
 
     var onUpdate: (() -> Void)?
+
+    init(newdata: Binding<ObservableAddConfigurations>) {
+        self.mode = .add
+        _newdata = newdata
+        _changesnapshotnum = .constant(false)
+        _stringestimate = .constant("")
+    }
+
+
+    init(
+        focusField: FocusState<AddConfigurationField?>,
+        newdata: Binding<ObservableAddConfigurations>,
+        changesnapshotnum: Binding<Bool>,
+        stringestimate: Binding<String>,
+        onUpdate: (() -> Void)?
+    ) {
+        self.mode = .update
+        _focusField = focusField
+        _newdata = newdata
+        _changesnapshotnum = changesnapshotnum
+        _stringestimate = stringestimate
+        self.onUpdate = onUpdate
+    }
 
     func loadTrailingSlashPreference() {
         if let value = UserDefaults.standard.value(forKey: "trailingslashoptions") as? String {
@@ -37,7 +59,7 @@ struct TaskForm: View {
     }
 
     var showSnapshot: Bool {
-        selectedconfig?.task == SharedReference.shared.snapshot
+        newdata.selectedconfig?.task == SharedReference.shared.snapshot
     }
 
     var synchronizeID: some View {
@@ -182,7 +204,7 @@ struct TaskForm: View {
                 localandremotecatalogsyncremote
             } else {
                 localandremotecatalog
-                    .disabled(selectedconfig?.task == SharedReference.shared.snapshot)
+                    .disabled(newdata.selectedconfig?.task == SharedReference.shared.snapshot)
             }
         }
     }

--- a/RsyncUI/Views/InspectorViews/Add/TaskForm.swift
+++ b/RsyncUI/Views/InspectorViews/Add/TaskForm.swift
@@ -18,7 +18,7 @@ struct TaskForm: View {
     @FocusState var focusField: AddConfigurationField?
 
     @Binding var newdata: ObservableAddConfigurations
-    @Binding var changesnapshotnum: Bool
+    @State var changesnapshotnum: Bool = false
     @Binding var stringestimate: String
 
     var onUpdate: (() -> Void)?
@@ -26,7 +26,6 @@ struct TaskForm: View {
     init(newdata: Binding<ObservableAddConfigurations>) {
         self.mode = .add
         _newdata = newdata
-        _changesnapshotnum = .constant(false)
         _stringestimate = .constant("")
     }
 
@@ -34,14 +33,12 @@ struct TaskForm: View {
     init(
         focusField: FocusState<AddConfigurationField?>,
         newdata: Binding<ObservableAddConfigurations>,
-        changesnapshotnum: Binding<Bool>,
         stringestimate: Binding<String>,
         onUpdate: (() -> Void)?
     ) {
         self.mode = .update
         _focusField = focusField
         _newdata = newdata
-        _changesnapshotnum = changesnapshotnum
         _stringestimate = stringestimate
         self.onUpdate = onUpdate
     }

--- a/RsyncUI/Views/InspectorViews/Add/extensionAddTaskView+BusinessLogic.swift
+++ b/RsyncUI/Views/InspectorViews/Add/extensionAddTaskView+BusinessLogic.swift
@@ -12,7 +12,6 @@ import SwiftUI
 extension AddTaskView {
     func clearSelection() {
         selecteduuids.removeAll()
-        selectedconfig = nil
         newdata.updateview(nil)
         newdata.showsaveurls = false
         changesnapshotnum = false
@@ -47,7 +46,6 @@ extension AddTaskView {
     func handleProfileChange() {
         newdata.resetForm()
         selecteduuids.removeAll()
-        selectedconfig = nil
     }
 
     func handleSelectionChange() {
@@ -56,11 +54,9 @@ extension AddTaskView {
                 return
             }
             if let index = configurations.firstIndex(where: { $0.id == selecteduuids.first }) {
-                selectedconfig = configurations[index]
                 newdata.updateview(configurations[index])
                 updateURLString()
             } else {
-                selectedconfig = nil
                 newdata.updateview(nil)
                 stringestimate = ""
                 newdata.showsaveurls = false
@@ -69,7 +65,7 @@ extension AddTaskView {
     }
 
     func updateURLString() {
-        if selectedconfig?.task == SharedReference.shared.synchronize {
+        if newdata.selectedconfig?.task == SharedReference.shared.synchronize {
             let deeplinkurl = DeeplinkURL()
             let urlestimate = deeplinkurl.createURLestimateandsynchronize(valueprofile: rsyncUIdata.profile ?? "Default")
             stringestimate = urlestimate?.absoluteString ?? ""

--- a/RsyncUI/Views/InspectorViews/Add/extensionAddTaskView+BusinessLogic.swift
+++ b/RsyncUI/Views/InspectorViews/Add/extensionAddTaskView+BusinessLogic.swift
@@ -14,7 +14,6 @@ extension AddTaskView {
         selecteduuids.removeAll()
         newdata.updateview(nil)
         newdata.showsaveurls = false
-        changesnapshotnum = false
         stringestimate = ""
     }
 

--- a/RsyncUI/Views/InspectorViews/InspectorContentView.swift
+++ b/RsyncUI/Views/InspectorViews/InspectorContentView.swift
@@ -18,7 +18,6 @@ struct InspectorContentView: View {
         case .edit:
             ScrollView {
                 AddTaskView(rsyncUIdata: rsyncUIdata,
-                            selectedTab: $selectedTab,
                             selecteduuids: $selecteduuids,
                             showAddPopover: $showAddPopover)
             }

--- a/RsyncUI/Views/InspectorViews/InspectorView.swift
+++ b/RsyncUI/Views/InspectorViews/InspectorView.swift
@@ -25,7 +25,6 @@ struct InspectorView: View {
         if selecteduuids.count == 0 {
             ZStack {
                 AddTaskView(rsyncUIdata: rsyncUIdata,
-                            selectedTab: $selectedTab,
                             selecteduuids: $selecteduuids,
                             showAddPopover: $showAddPopover)
                     .opacity(0)


### PR DESCRIPTION
This PR cleans up `TaskForm` bindings and adds distinct `add` and `update` init methods.