### PR TITLE
Move add task sheet

### DIFF
--- a/RsyncUI/Views/InspectorViews/Add/AddTaskSheetView.swift
+++ b/RsyncUI/Views/InspectorViews/Add/AddTaskSheetView.swift
@@ -9,32 +9,32 @@ import SwiftUI
 
 struct AddTaskSheetView: View {
     @Environment(\.dismiss) var dismiss
-    
+
     @State var newdata = ObservableAddConfigurations()
 
     var onAdd: (ObservableAddConfigurations) -> Void
 
-        var body: some View {
-            VStack {
-                Text("Add Task")
-                    .font(.title2)
+    var body: some View {
+        VStack {
+            Text("Add Task")
+                .font(.title2)
 
-                TaskForm(newdata: $newdata)
-            }
-            .padding()
-            .frame(minWidth: 600)
-            .toolbar {
-                ToolbarItem(placement: .confirmationAction) {
-                    Button("Add") {
-                        onAdd(newdata)
-                    }
+            TaskForm(newdata: $newdata)
+        }
+        .padding()
+        .frame(minWidth: 600)
+        .toolbar {
+            ToolbarItem(placement: .confirmationAction) {
+                Button("Add") {
+                    onAdd(newdata)
                 }
+            }
 
-                ToolbarItem(placement: .cancellationAction) {
-                    Button("Cancel") {
-                        dismiss()
-                    }
+            ToolbarItem(placement: .cancellationAction) {
+                Button("Cancel") {
+                    dismiss()
                 }
             }
         }
     }
+}

--- a/RsyncUI/Views/InspectorViews/Add/AddTaskView.swift
+++ b/RsyncUI/Views/InspectorViews/Add/AddTaskView.swift
@@ -39,15 +39,6 @@ struct AddTaskView: View {
 
     @State var newdata = ObservableAddConfigurations()
     @State var stringestimate: String = ""
-    @Binding var showAddPopover: Bool
-
-    func onAdd(newdata: ObservableAddConfigurations) {
-        Task { @MainActor in
-            if await addConfig(newdata: newdata) {
-                showAddPopover = false
-            }
-        }
-    }
 
     func onUpdate() {
         Task { @MainActor in
@@ -62,6 +53,5 @@ struct AddTaskView: View {
         .onSubmit { handleSubmit() }
         .onChange(of: rsyncUIdata.profile) { handleProfileChange() }
         .onChange(of: selecteduuids) { handleSelectionChange() }
-        .sheet(isPresented: $showAddPopover) { AddTaskSheetView(onAdd: onAdd) }
     }
 }

--- a/RsyncUI/Views/InspectorViews/Add/extensionAddTaskView+BusinessLogic.swift
+++ b/RsyncUI/Views/InspectorViews/Add/extensionAddTaskView+BusinessLogic.swift
@@ -28,11 +28,7 @@ extension AddTaskView {
                 _ = await validateAndUpdate()
             }
         case .remoteserverField:
-            if newdata.selectedconfig == nil {
-                Task { @MainActor in
-                    _ = await addConfig(newdata: newdata)
-                }
-            } else {
+            if newdata.selectedconfig != nil {
                 Task { @MainActor in
                     _ = await validateAndUpdate()
                 }

--- a/RsyncUI/Views/InspectorViews/Add/extensionAddTaskView.swift
+++ b/RsyncUI/Views/InspectorViews/Add/extensionAddTaskView.swift
@@ -11,19 +11,6 @@ import SwiftUI
 
 extension AddTaskView {
     @MainActor
-    func addConfig(newdata: ObservableAddConfigurations) async -> Bool {
-        let profile = rsyncUIdata.profile
-        let beforeCount = rsyncUIdata.configurations?.count ?? 0
-        rsyncUIdata.configurations = await newdata.addConfig(profile, rsyncUIdata.configurations)
-        if SharedReference.shared.duplicatecheck {
-            if let configurations = rsyncUIdata.configurations {
-                VerifyDuplicates(configurations)
-            }
-        }
-        return (rsyncUIdata.configurations?.count ?? 0) > beforeCount
-    }
-
-    @MainActor
     func validateAndUpdate() async -> Bool {
         let profile = rsyncUIdata.profile
         let selectedHiddenID = newdata.selectedconfig?.hiddenID

--- a/RsyncUI/Views/InspectorViews/EditTabView.swift
+++ b/RsyncUI/Views/InspectorViews/EditTabView.swift
@@ -12,6 +12,27 @@ struct EditTabView: View {
     @State private var selecteduuids = Set<SynchronizeConfiguration.ID>()
     @State private var showAddPopover: Bool = false
 
+    @MainActor
+    func addConfig(newdata: ObservableAddConfigurations) async -> Bool {
+        let profile = rsyncUIdata.profile
+        let beforeCount = rsyncUIdata.configurations?.count ?? 0
+        rsyncUIdata.configurations = await newdata.addConfig(profile, rsyncUIdata.configurations)
+        if SharedReference.shared.duplicatecheck {
+            if let configurations = rsyncUIdata.configurations {
+                VerifyDuplicates(configurations)
+            }
+        }
+        return (rsyncUIdata.configurations?.count ?? 0) > beforeCount
+    }
+
+    func onAdd(newdata: ObservableAddConfigurations) {
+        Task { @MainActor in
+            if await addConfig(newdata: newdata) {
+                showAddPopover = false
+            }
+        }
+    }
+
     var body: some View {
         HStack {
             // Shared task list table on the left
@@ -23,6 +44,8 @@ struct EditTabView: View {
             .onChange(of: rsyncUIdata.profile) {
                 selecteduuids.removeAll()
             }
+            .sheet(isPresented: $showAddPopover) { AddTaskSheetView(onAdd: onAdd) }
+
 
         }
         .task(id: rsyncUIdata.configurations) {
@@ -34,8 +57,7 @@ struct EditTabView: View {
         }
         .inspector(isPresented: .constant(true)) {
             InspectorView(rsyncUIdata: rsyncUIdata,
-                          selecteduuids: $selecteduuids,
-                          showAddPopover: $showAddPopover)
+                          selecteduuids: $selecteduuids)
         }
         .toolbar(content: {
             ToolbarItem(placement: .status) {

--- a/RsyncUI/Views/InspectorViews/InspectorContentView.swift
+++ b/RsyncUI/Views/InspectorViews/InspectorContentView.swift
@@ -11,15 +11,13 @@ struct InspectorContentView: View {
     @Bindable var rsyncUIdata: RsyncUIconfigurations
     @Binding var selectedTab: InspectorTab
     @Binding var selecteduuids: Set<SynchronizeConfiguration.ID>
-    @Binding var showAddPopover: Bool
 
     var body: some View {
         switch selectedTab {
         case .edit:
             ScrollView {
                 AddTaskView(rsyncUIdata: rsyncUIdata,
-                            selecteduuids: $selecteduuids,
-                            showAddPopover: $showAddPopover)
+                            selecteduuids: $selecteduuids)
             }
         case .parameters:
             ScrollView {

--- a/RsyncUI/Views/InspectorViews/InspectorView.swift
+++ b/RsyncUI/Views/InspectorViews/InspectorView.swift
@@ -17,19 +17,12 @@ enum InspectorTab: Hashable {
 struct InspectorView: View {
     @Bindable var rsyncUIdata: RsyncUIconfigurations
     @Binding var selecteduuids: Set<SynchronizeConfiguration.ID>
-    @Binding var showAddPopover: Bool
 
     @State private var selectedTab: InspectorTab = .edit
 
     var body: some View {
         if selecteduuids.count == 0 {
             ZStack {
-                AddTaskView(rsyncUIdata: rsyncUIdata,
-                            selecteduuids: $selecteduuids,
-                            showAddPopover: $showAddPopover)
-                    .opacity(0)
-                    .allowsHitTesting(false)
-
                 Text("No task\nselected")
                     .font(.title2)
             }
@@ -51,8 +44,7 @@ struct InspectorView: View {
                 InspectorContentView(
                     rsyncUIdata: rsyncUIdata,
                     selectedTab: $selectedTab,
-                    selecteduuids: $selecteduuids,
-                    showAddPopover: $showAddPopover
+                    selecteduuids: $selecteduuids
                 )
             }
             .navigationTitle("")


### PR DESCRIPTION
This PR moves the sheet logic to `EditTabView`.
This allows for the removal of `AddTaskView` in `InspectorView` which is marked as `.opacity(0)` and `.allowsHitTesting(false)`.