### PR TITLE
Fix P1

### DIFF
--- a/RsyncUI/Model/Global/ObservableAddConfigurations.swift
+++ b/RsyncUI/Model/Global/ObservableAddConfigurations.swift
@@ -123,6 +123,7 @@ final class ObservableAddConfigurations {
     func updateview(_ config: SynchronizeConfiguration?) {
         selectedconfig = config
         if let config = selectedconfig {
+            selectedrsynccommand = TypeofTask(rawValue: config.task) ?? .synchronize
             localcatalog = config.localCatalog
             remotecatalog = config.offsiteCatalog
             remoteuser = config.offsiteUsername

--- a/RsyncUI/Model/Global/ObservableAddConfigurations.swift
+++ b/RsyncUI/Model/Global/ObservableAddConfigurations.swift
@@ -135,7 +135,7 @@ final class ObservableAddConfigurations {
                 }
             }
         } else {
-            selectedconfig = nil
+            selectedrsynccommand = .synchronize
             localcatalog = ""
             remotecatalog = ""
             remoteuser = ""

--- a/RsyncUI/Views/InspectorViews/Add/AddTaskSheetView.swift
+++ b/RsyncUI/Views/InspectorViews/Add/AddTaskSheetView.swift
@@ -12,6 +12,18 @@ struct AddTaskSheetView: View {
     
     @State var newdata = ObservableAddConfigurations()
 
+    func loadTrailingSlashPreference() {
+        if let value = UserDefaults.standard.value(forKey: "trailingslashoptions") as? String {
+            newdata.trailingslashoptions = TrailingSlash(rawValue: value) ?? .add
+        }
+    }
+
+    func loadRsyncCommandPreference() {
+        if let value = UserDefaults.standard.value(forKey: "selectedrsynccommand") as? String {
+            newdata.selectedrsynccommand = TypeofTask(rawValue: value) ?? .synchronize
+        }
+    }
+
     var onAdd: (ObservableAddConfigurations) -> Void
 
         var body: some View {
@@ -20,6 +32,10 @@ struct AddTaskSheetView: View {
                     .font(.title2)
 
                 TaskForm(newdata: $newdata)
+            }
+            .onAppear {
+                loadTrailingSlashPreference()
+                loadRsyncCommandPreference()
             }
             .padding()
             .frame(minWidth: 600)

--- a/RsyncUI/Views/InspectorViews/Add/TaskForm.swift
+++ b/RsyncUI/Views/InspectorViews/Add/TaskForm.swift
@@ -43,18 +43,6 @@ struct TaskForm: View {
         self.onUpdate = onUpdate
     }
 
-    func loadTrailingSlashPreference() {
-        if let value = UserDefaults.standard.value(forKey: "trailingslashoptions") as? String {
-            newdata.trailingslashoptions = TrailingSlash(rawValue: value) ?? .add
-        }
-    }
-
-    func loadRsyncCommandPreference() {
-        if let value = UserDefaults.standard.value(forKey: "selectedrsynccommand") as? String {
-            newdata.selectedrsynccommand = TypeofTask(rawValue: value) ?? .synchronize
-        }
-    }
-
     var showSnapshot: Bool {
         newdata.selectedconfig?.task == SharedReference.shared.snapshot
     }
@@ -181,7 +169,6 @@ struct TaskForm: View {
         .onChange(of: newdata.trailingslashoptions) {
             UserDefaults.standard.set(newdata.trailingslashoptions.rawValue, forKey: "trailingslashoptions")
         }
-        .onAppear { loadTrailingSlashPreference() }
     }
 
     var pickerselecttypeoftask: some View {
@@ -192,7 +179,6 @@ struct TaskForm: View {
         .onChange(of: newdata.selectedrsynccommand) {
             UserDefaults.standard.set(newdata.selectedrsynccommand.rawValue, forKey: "selectedrsynccommand")
         }
-        .onAppear { loadRsyncCommandPreference() }
     }
 
     var catalogSectionView: some View {


### PR DESCRIPTION
This PR addresses the [P1](https://github.com/rsyncOSX/RsyncUI/blob/version-3.0.4-tr/issues.md#p1--update-mode-does-not-load-the-selected-task-type) issue that `selectedrsynccommand` is not updated with `updateview`.
It seems this issue already existed before but was not caught by the issue reporter.