### PR TITLE
Fix P2 sheet present

### DIFF
--- a/RsyncUI/Views/InspectorViews/EditTabView.swift
+++ b/RsyncUI/Views/InspectorViews/EditTabView.swift
@@ -25,11 +25,9 @@ struct EditTabView: View {
             }
 
         }
-        .task(id: rsyncUIdata.configurations) {
-            if rsyncUIdata.configurations == nil {
-                showAddPopover = true
-            } else if let config = rsyncUIdata.configurations, config.isEmpty {
-                showAddPopover = true
+        .onAppear {
+            if (!showAddPopover) {
+                showAddPopover = rsyncUIdata.configurations?.isEmpty ?? true
             }
         }
         .inspector(isPresented: .constant(true)) {

--- a/RsyncUI/Views/InspectorViews/EditTabView.swift
+++ b/RsyncUI/Views/InspectorViews/EditTabView.swift
@@ -25,7 +25,7 @@ struct EditTabView: View {
             }
 
         }
-        .onAppear {
+        .onChange(of: rsyncUIdata.configurations, initial: true) {
             if (!showAddPopover) {
                 showAddPopover = rsyncUIdata.configurations?.isEmpty ?? true
             }


### PR DESCRIPTION
  This PR addresses the [P2](https://github.com/rsyncOSX/RsyncUI/blob/version-3.0.4-tr/issues.md#p2--automatic-and-user-requested-sheet-presentation-share-a-latched-boolean) issue that user-requested sheet presentation share a latched Boolean.