### PR TITLE
Fix P2 submit

### DIFF
--- a/RsyncUI/Views/InspectorViews/Add/AddTaskSheetView.swift
+++ b/RsyncUI/Views/InspectorViews/Add/AddTaskSheetView.swift
@@ -9,32 +9,37 @@ import SwiftUI
 
 struct AddTaskSheetView: View {
     @Environment(\.dismiss) var dismiss
-    
+
+    @FocusState.Binding var focusField: AddConfigurationField?
     @State var newdata = ObservableAddConfigurations()
 
     var onAdd: (ObservableAddConfigurations) -> Void
+    var onSubmit: () -> Void
 
-        var body: some View {
-            VStack {
-                Text("Add Task")
-                    .font(.title2)
+    var body: some View {
+        VStack {
+            Text("Add Task")
+                .font(.title2)
 
-                TaskForm(newdata: $newdata)
-            }
-            .padding()
-            .frame(minWidth: 600)
-            .toolbar {
-                ToolbarItem(placement: .confirmationAction) {
-                    Button("Add") {
-                        onAdd(newdata)
-                    }
+            TaskForm(focusField: $focusField, newdata: $newdata)
+                .onSubmit {
+                    onSubmit()
                 }
+        }
+        .padding()
+        .frame(minWidth: 600)
+        .toolbar {
+            ToolbarItem(placement: .confirmationAction) {
+                Button("Add") {
+                    onAdd(newdata)
+                }
+            }
 
-                ToolbarItem(placement: .cancellationAction) {
-                    Button("Cancel") {
-                        dismiss()
-                    }
+            ToolbarItem(placement: .cancellationAction) {
+                Button("Cancel") {
+                    dismiss()
                 }
             }
         }
     }
+}

--- a/RsyncUI/Views/InspectorViews/Add/AddTaskView.swift
+++ b/RsyncUI/Views/InspectorViews/Add/AddTaskView.swift
@@ -56,12 +56,12 @@ struct AddTaskView: View {
     }
 
     var body: some View {
-        TaskForm(focusField: _focusField, newdata: $newdata, stringestimate: $stringestimate, onUpdate: onUpdate)
+        TaskForm(focusField: $focusField, newdata: $newdata, stringestimate: $stringestimate, onUpdate: onUpdate)
         .padding()
         .onAppear { handleSelectionChange() }
         .onSubmit { handleSubmit() }
         .onChange(of: rsyncUIdata.profile) { handleProfileChange() }
         .onChange(of: selecteduuids) { handleSelectionChange() }
-        .sheet(isPresented: $showAddPopover) { AddTaskSheetView(onAdd: onAdd) }
+        .sheet(isPresented: $showAddPopover) { AddTaskSheetView(focusField: $focusField, onAdd: onAdd, onSubmit: handleSubmit) }
     }
 }

--- a/RsyncUI/Views/InspectorViews/Add/TaskForm.swift
+++ b/RsyncUI/Views/InspectorViews/Add/TaskForm.swift
@@ -15,7 +15,7 @@ private enum TaskFormMode {
 struct TaskForm: View {
     private let mode: TaskFormMode
 
-    @FocusState var focusField: AddConfigurationField?
+    @FocusState.Binding var focusField: AddConfigurationField?
 
     @Binding var newdata: ObservableAddConfigurations
     @State var changesnapshotnum: Bool = false
@@ -23,15 +23,16 @@ struct TaskForm: View {
 
     var onUpdate: (() -> Void)?
 
-    init(newdata: Binding<ObservableAddConfigurations>) {
+    init(focusField: FocusState<AddConfigurationField?>.Binding, newdata: Binding<ObservableAddConfigurations>) {
         self.mode = .add
+        _focusField = focusField
         _newdata = newdata
         _stringestimate = .constant("")
     }
 
 
     init(
-        focusField: FocusState<AddConfigurationField?>,
+        focusField: FocusState<AddConfigurationField?>.Binding,
         newdata: Binding<ObservableAddConfigurations>,
         stringestimate: Binding<String>,
         onUpdate: (() -> Void)?


### PR DESCRIPTION
  This PR addresses the [P2](https://github.com/rsyncOSX/RsyncUI/blob/version-3.0.4-tr/issues.md#p2--returnsubmit-handling-was-lost-from-the-add-task-sheet) issue that submit is not handled in `AddTaskSheetView`.