### PR TITLE
Fix Issues

### DIFF
--- a/RsyncUI/Views/InspectorViews/Add/AddTaskSheetView.swift
+++ b/RsyncUI/Views/InspectorViews/Add/AddTaskSheetView.swift
@@ -26,7 +26,7 @@ struct AddTaskSheetView: View {
     }
 
     var onAdd: (ObservableAddConfigurations) -> Void
-    var onSubmit: () -> Void
+    var onSubmit: (ObservableAddConfigurations) -> Void
 
     var body: some View {
         VStack {
@@ -35,7 +35,7 @@ struct AddTaskSheetView: View {
 
             TaskForm(focusField: $focusField, newdata: $newdata)
                 .onSubmit {
-                    onSubmit()
+                    onSubmit(newdata)
                 }
                 .onAppear {
                     loadTrailingSlashPreference()

--- a/RsyncUI/Views/InspectorViews/Add/AddTaskSheetView.swift
+++ b/RsyncUI/Views/InspectorViews/Add/AddTaskSheetView.swift
@@ -49,15 +49,6 @@ struct AddTaskSheetView: View {
                             onAdd(newdata)
                         }
                     }
-                }
-                .padding()
-                .frame(minWidth: 600)
-                .toolbar {
-                    ToolbarItem(placement: .confirmationAction) {
-                        Button("Add") {
-                            onAdd(newdata)
-                        }
-                    }
 
                     ToolbarItem(placement: .cancellationAction) {
                         Button("Cancel") {

--- a/RsyncUI/Views/InspectorViews/Add/AddTaskView.swift
+++ b/RsyncUI/Views/InspectorViews/Add/AddTaskView.swift
@@ -57,11 +57,11 @@ struct AddTaskView: View {
 
     var body: some View {
         TaskForm(focusField: $focusField, newdata: $newdata, stringestimate: $stringestimate, onUpdate: onUpdate)
-        .padding()
-        .onAppear { handleSelectionChange() }
-        .onSubmit { handleSubmit() }
-        .onChange(of: rsyncUIdata.profile) { handleProfileChange() }
-        .onChange(of: selecteduuids) { handleSelectionChange() }
-        .sheet(isPresented: $showAddPopover) { AddTaskSheetView(focusField: $focusField, onAdd: onAdd, onSubmit: handleSubmit) }
+            .padding()
+            .onAppear { handleSelectionChange() }
+            .onSubmit { handleSubmit(newdata) }
+            .onChange(of: rsyncUIdata.profile) { handleProfileChange() }
+            .onChange(of: selecteduuids) { handleSelectionChange() }
+            .sheet(isPresented: $showAddPopover) { AddTaskSheetView(focusField: $focusField, onAdd: onAdd, onSubmit: handleSubmit) }
     }
 }

--- a/RsyncUI/Views/InspectorViews/Add/TaskForm.swift
+++ b/RsyncUI/Views/InspectorViews/Add/TaskForm.swift
@@ -30,7 +30,6 @@ struct TaskForm: View {
         _stringestimate = .constant("")
     }
 
-
     init(
         focusField: FocusState<AddConfigurationField?>.Binding,
         newdata: Binding<ObservableAddConfigurations>,
@@ -58,7 +57,11 @@ struct TaskForm: View {
                 TextField("Synchronize ID", text: $newdata.backupID)
                     .focused($focusField, equals: .synchronizeIDField)
                     .textContentType(.none).submitLabel(.continue)
-                    .onAppear { if let id = newdata.selectedconfig?.backupID { newdata.backupID = id } }
+                    .onAppear {
+                        if let id = newdata.selectedconfig?.backupID {
+                            newdata.backupID = id
+                        }
+                    }
             }
         }
     }
@@ -84,7 +87,7 @@ struct TaskForm: View {
                          focus: .remotecatalogField,
                          selectedValue: newdata.selectedconfig?.offsiteCatalog,
                          showErrorBorder: !newdata.localcatalog.isEmpty && newdata.remotecatalog.isEmpty ||
-                         newdata.localcatalog.isEmpty && !newdata.remotecatalog.isEmpty)
+                             newdata.localcatalog.isEmpty && !newdata.remotecatalog.isEmpty)
         }
     }
 
@@ -99,13 +102,14 @@ struct TaskForm: View {
                          focus: .localcatalogField,
                          selectedValue: newdata.selectedconfig?.localCatalog,
                          showErrorBorder: !newdata.localcatalog.isEmpty && newdata.remotecatalog.isEmpty ||
-                         newdata.localcatalog.isEmpty && !newdata.remotecatalog.isEmpty)
+                             newdata.localcatalog.isEmpty && !newdata.remotecatalog.isEmpty)
         }
     }
 
     func catalogField(catalog: Binding<String>, placeholder: String,
                       focus: AddConfigurationField, selectedValue: String?,
-                      showErrorBorder: Bool = false) -> some View {
+                      showErrorBorder: Bool = false) -> some View
+    {
         HStack {
             if newdata.selectedconfig == nil {
                 TextField(placeholder, text: catalog)
@@ -116,7 +120,11 @@ struct TaskForm: View {
                 TextField(placeholder, text: catalog)
                     .focused($focusField, equals: focus)
                     .textContentType(.none).submitLabel(.continue)
-                    .onAppear { if let value = selectedValue { catalog.wrappedValue = value } }
+                    .onAppear {
+                        if let value = selectedValue {
+                            catalog.wrappedValue = value
+                        }
+                    }
                     .border(showErrorBorder ? Color.red : Color.clear, width: 2)
             }
             OpencatalogView(selecteditem: catalog, catalogs: true)
@@ -143,22 +151,26 @@ struct TaskForm: View {
         }
     }
 
+    @ViewBuilder
     func remoteField(value: Binding<String>, placeholder: String, focus: AddConfigurationField,
                      selectedValue: String?, submitLabel: SubmitLabel = .continue,
-                     showErrorBorder: Bool = false) -> some View {
-        Group {
-            if newdata.selectedconfig == nil {
-                TextField(placeholder, text: value)
-                    .focused($focusField, equals: focus)
-                    .textContentType(.none).submitLabel(submitLabel)
-                    .border(showErrorBorder ? Color.red : Color.clear, width: 2)
-            } else {
-                TextField(placeholder, text: value)
-                    .focused($focusField, equals: focus)
-                    .textContentType(.none).submitLabel(submitLabel)
-                    .onAppear { if let val = selectedValue { value.wrappedValue = val } }
-                    .border(showErrorBorder ? Color.red : Color.clear, width: 2)
-            }
+                     showErrorBorder: Bool = false) -> some View
+    {
+        if newdata.selectedconfig == nil {
+            TextField(placeholder, text: value)
+                .focused($focusField, equals: focus)
+                .textContentType(.none).submitLabel(submitLabel)
+                .border(showErrorBorder ? Color.red : Color.clear, width: 2)
+        } else {
+            TextField(placeholder, text: value)
+                .focused($focusField, equals: focus)
+                .textContentType(.none).submitLabel(submitLabel)
+                .onAppear {
+                    if let val = selectedValue {
+                        value.wrappedValue = val
+                    }
+                }
+                .border(showErrorBorder ? Color.red : Color.clear, width: 2)
         }
     }
 
@@ -182,14 +194,13 @@ struct TaskForm: View {
         }
     }
 
+    @ViewBuilder
     var catalogSectionView: some View {
-        Group {
-            if newdata.selectedrsynccommand == .syncremote {
-                localandremotecatalogsyncremote
-            } else {
-                localandremotecatalog
-                    .disabled(newdata.selectedconfig?.task == SharedReference.shared.snapshot)
-            }
+        if newdata.selectedrsynccommand == .syncremote {
+            localandremotecatalogsyncremote
+        } else {
+            localandremotecatalog
+                .disabled(newdata.selectedconfig?.task == SharedReference.shared.snapshot)
         }
     }
 
@@ -200,24 +211,23 @@ struct TaskForm: View {
         .help("Update task")
     }
 
+    @ViewBuilder
     var saveURLSection: some View {
-        Group {
-            Toggle("Show save URL", isOn: $newdata.showsaveurls).toggleStyle(.switch)
-            if newdata.showsaveurls {
-                ConditionalGlassButton(systemImage: "square.and.arrow.down",
-                                       text: "URL Estimate",
-                                       helpText: "URL Estimate & Synchronize") {
-                    let data = WidgetURLstrings(urletimate: stringestimate)
-                    Task { @MainActor in
-                        await WriteWidgetsURLStringsJSON.write(data)
-                    }
+        Toggle("Show save URL", isOn: $newdata.showsaveurls).toggleStyle(.switch)
+        if newdata.showsaveurls {
+            ConditionalGlassButton(systemImage: "square.and.arrow.down",
+                                   text: "URL Estimate",
+                                   helpText: "URL Estimate & Synchronize")
+            {
+                let data = WidgetURLstrings(urletimate: stringestimate)
+                Task { @MainActor in
+                    await WriteWidgetsURLStringsJSON.write(data)
                 }
             }
         }
     }
 
     var body: some View {
-
         switch mode {
         case .add:
             Form {
@@ -236,10 +246,11 @@ struct TaskForm: View {
                 catalogSectionView
                 remoteuserandserver
 
-                if showSnapshot { snapshotnum }
+                if showSnapshot {
+                    snapshotnum
+                }
                 saveURLSection
                 updateButton
-
             }
             .formStyle(.grouped)
         }

--- a/RsyncUI/Views/InspectorViews/Add/extensionAddTaskView+BusinessLogic.swift
+++ b/RsyncUI/Views/InspectorViews/Add/extensionAddTaskView+BusinessLogic.swift
@@ -17,7 +17,7 @@ extension AddTaskView {
         stringestimate = ""
     }
 
-    func handleSubmit() {
+    func handleSubmit(_ newdata: ObservableAddConfigurations) {
         switch focusField {
         case .synchronizeIDField: focusField = .localcatalogField
         case .localcatalogField: focusField = .remotecatalogField
@@ -72,5 +72,4 @@ extension AddTaskView {
             stringestimate = ""
         }
     }
-
 }

--- a/RsyncUI/Views/InspectorViews/EditTabView.swift
+++ b/RsyncUI/Views/InspectorViews/EditTabView.swift
@@ -23,11 +23,11 @@ struct EditTabView: View {
             .onChange(of: rsyncUIdata.profile) {
                 selecteduuids.removeAll()
             }
-
         }
         .onChange(of: rsyncUIdata.configurations, initial: true) {
-            if (!showAddPopover) {
-                showAddPopover = rsyncUIdata.configurations?.isEmpty ?? true
+            guard let configurations = rsyncUIdata.configurations else { return }
+            if !showAddPopover {
+                showAddPopover = configurations.isEmpty
             }
         }
         .inspector(isPresented: .constant(true)) {


### PR DESCRIPTION
This PR fixes
- [P1 — Add-sheet Return invokes submit logic on the parent edit model](https://github.com/rsyncOSX/RsyncUI/blob/version-3.0.4-tr/issues.md#p1--add-sheet-return-invokes-submit-logic-on-the-parent-edit-model)
- [P2 — Add Task sheet declares the Add toolbar action twice](https://github.com/rsyncOSX/RsyncUI/blob/version-3.0.4-tr/issues.md#p2--add-task-sheet-declares-the-add-toolbar-action-twice)
- [P2 — Automatic Add Task presentation remains latched](https://github.com/rsyncOSX/RsyncUI/blob/version-3.0.4-tr/issues.md#p2--automatic-add-task-presentation-remains-latched)
- [P3 — Formatting checks still fail on changed Swift files](https://github.com/rsyncOSX/RsyncUI/blob/version-3.0.4-tr/issues.md#p3--formatting-checks-still-fail-on-changed-swift-files) (updated by `swiftformat`)