### PR TITLE
Remove `trailingslash` variable

### DIFF
--- a/RsyncUI/Model/Global/ObservableAddConfigurations.swift
+++ b/RsyncUI/Model/Global/ObservableAddConfigurations.swift
@@ -11,7 +11,6 @@ import OSLog
 
 @Observable @MainActor
 final class ObservableAddConfigurations {
-    var trailingslash = true
     var selectedrsynccommand = TypeofTask.synchronize
 
     var localcatalog: String = ""
@@ -35,7 +34,6 @@ final class ObservableAddConfigurations {
         let getdata = NewTask(selectedrsynccommand.rawValue,
                               localcatalog.replacingOccurrences(of: "\"", with: ""),
                               remotecatalog.replacingOccurrences(of: "\"", with: ""),
-                              trailingslash,
                               remoteuser,
                               remoteserver,
                               backupID)
@@ -61,15 +59,11 @@ final class ObservableAddConfigurations {
             }
         }
 
-        if localcatalog.hasSuffix("/") == false {
-            trailingslash = false
-        }
-
         guard let hiddenID = selectedconfig?.hiddenID else { return nil }
         let updateddata = NewTask(selectedrsynccommand.rawValue,
                                   localcatalog.replacingOccurrences(of: "\"", with: ""),
                                   remotecatalog.replacingOccurrences(of: "\"", with: ""),
-                                  trailingslash,
+
                                   remoteuser,
                                   remoteserver,
                                   backupID,

--- a/RsyncUI/Model/Storage/Basic/NewTask.swift
+++ b/RsyncUI/Model/Storage/Basic/NewTask.swift
@@ -7,11 +7,11 @@
 
 import Foundation
 
-struct NewTask {
+struct NewTask
+{
     var newtask: String
     var newlocalCatalog: String
     var newoffsiteCatalog: String
-    var newtrailingslash: Bool
     // Can be nil
     var newoffsiteUsername: String?
     var newoffsiteServer: String?
@@ -24,14 +24,13 @@ struct NewTask {
     init(_ task: String,
          _ localCatalog: String,
          _ offsiteCatalog: String,
-         _ trailingslash: Bool,
          _ offsiteUsername: String?,
          _ offsiteServer: String?,
-         _ backupID: String?) {
+         _ backupID: String?)
+    {
         newtask = task
         newlocalCatalog = localCatalog
         newoffsiteCatalog = offsiteCatalog
-        newtrailingslash = trailingslash
         newoffsiteUsername = offsiteUsername
         newoffsiteServer = offsiteServer
         newbackupID = backupID
@@ -40,16 +39,15 @@ struct NewTask {
     init(_ task: String,
          _ localCatalog: String,
          _ offsiteCatalog: String,
-         _ trailingslash: Bool,
          _ offsiteUsername: String?,
          _ offsiteServer: String?,
          _ backupID: String?,
          _ updatedhiddenID: Int,
-         _ updatesnapshotnum: Int?) {
+         _ updatesnapshotnum: Int?)
+    {
         newtask = task
         newlocalCatalog = localCatalog
         newoffsiteCatalog = offsiteCatalog
-        newtrailingslash = trailingslash
         newoffsiteUsername = offsiteUsername
         newoffsiteServer = offsiteServer
         newbackupID = backupID

--- a/RsyncUI/Model/Storage/Basic/VerifyConfiguration.swift
+++ b/RsyncUI/Model/Storage/Basic/VerifyConfiguration.swift
@@ -63,7 +63,6 @@ final class VerifyConfiguration: Connected {
 
         newconfig.snapshotnum = (data.snapshotnum ?? 0) > 0 ? data.snapshotnum : nil
 
-        handleTrailingSlash(data: data, newconfig: &newconfig)
         handleSnapshotAndSyncRemote(data: data, newconfig: &newconfig)
 
         do {
@@ -79,13 +78,6 @@ final class VerifyConfiguration: Connected {
         }
 
         return newconfig
-    }
-
-    private func handleTrailingSlash(data: NewTask, newconfig: inout SynchronizeConfiguration) {
-        if data.newtrailingslash {
-            newconfig.localCatalog = data.newlocalCatalog.hasSuffix("/") ?
-                data.newlocalCatalog : data.newlocalCatalog + "/"
-        }
     }
 
     private func handleSnapshotAndSyncRemote(data: NewTask, newconfig: inout SynchronizeConfiguration) {

--- a/RsyncUI/Model/Storage/Basic/VerifyObservableAddConfiguration.swift
+++ b/RsyncUI/Model/Storage/Basic/VerifyObservableAddConfiguration.swift
@@ -29,7 +29,6 @@ struct VerifyObservableAddConfiguration: Connected {
         let data = NewTask(observed.selectedrsynccommand.rawValue,
                            observed.localcatalog.replacingOccurrences(of: "\"", with: ""),
                            observed.remotecatalog.replacingOccurrences(of: "\"", with: ""),
-                           observed.trailingslash,
                            observed.remoteuser,
                            observed.remoteserver,
                            observed.backupID,
@@ -60,17 +59,9 @@ struct VerifyObservableAddConfiguration: Connected {
 
         newconfig.snapshotnum = (data.snapshotnum ?? 0) > 0 ? data.snapshotnum : nil
 
-        handleTrailingSlash(data: data, newconfig: &newconfig)
         handleSnapshotAndSyncRemote(data: data, newconfig: &newconfig)
 
         return validateInput(config: newconfig)
-    }
-
-    private func handleTrailingSlash(data: NewTask, newconfig: inout SynchronizeConfiguration) {
-        if data.newtrailingslash {
-            newconfig.localCatalog = data.newlocalCatalog.hasSuffix("/") ?
-                data.newlocalCatalog : data.newlocalCatalog + "/"
-        }
     }
 
     private func handleSnapshotAndSyncRemote(data: NewTask, newconfig: inout SynchronizeConfiguration) {

--- a/RsyncUI/Views/InspectorViews/Add/AddTaskSheetView.swift
+++ b/RsyncUI/Views/InspectorViews/Add/AddTaskSheetView.swift
@@ -13,12 +13,6 @@ struct AddTaskSheetView: View {
     @FocusState.Binding var focusField: AddConfigurationField?
     @State var newdata = ObservableAddConfigurations()
 
-    func loadTrailingSlashPreference() {
-        if let trailingslashoptions = UserDefaults.standard.value(forKey: "trailingslashoptions") {
-            newdata.trailingslash = trailingslashoptions as? Bool ?? false
-        }
-    }
-
     func loadRsyncCommandPreference() {
         if let value = UserDefaults.standard.value(forKey: "selectedrsynccommand") as? String {
             newdata.selectedrsynccommand = TypeofTask(rawValue: value) ?? .synchronize
@@ -38,7 +32,6 @@ struct AddTaskSheetView: View {
                     onSubmit(newdata)
                 }
                 .onAppear {
-                    loadTrailingSlashPreference()
                     loadRsyncCommandPreference()
                 }
                 .padding()

--- a/RsyncUI/Views/InspectorViews/Add/TaskForm.swift
+++ b/RsyncUI/Views/InspectorViews/Add/TaskForm.swift
@@ -77,6 +77,7 @@ struct TaskForm: View {
 
     var localandremotecatalog: some View {
         Section("Folders") {
+            trailingSlashToggle(for: $newdata.localcatalog)
             catalogField(catalog: $newdata.localcatalog,
                          placeholder: "Source folder (required)",
                          focus: .localcatalogField,
@@ -91,6 +92,7 @@ struct TaskForm: View {
 
     var localandremotecatalogsyncremote: some View {
         Section("Folders") {
+            trailingSlashToggle(for: $newdata.remotecatalog)
             catalogField(catalog: $newdata.remotecatalog,
                          placeholder: "Source Folder (required)",
                          focus: .remotecatalogField,
@@ -156,21 +158,27 @@ struct TaskForm: View {
             .border(showErrorBorder ? Color.red : Color.clear, width: 2)
     }
 
-    var trailingslash: some View {
-        Toggle("Trailing / (slash) on source folder", isOn: $newdata.trailingslash)
-            .onChange(of: newdata.trailingslash) {
-                UserDefaults.standard.set(newdata.trailingslash, forKey: "trailingslashoptions")
-                
-                if newdata.trailingslash {
-                    if newdata.localcatalog.hasSuffix("/") == false {
-                        newdata.localcatalog.append("/")
+    func trailingSlashToggle(for value: Binding<String>) -> some View {
+        Toggle("Trailing Slash on Source folder", isOn: Binding(
+            get: {
+                value.wrappedValue.hasSuffix("/")
+            },
+            set: { enabled in
+                var text = value.wrappedValue
+
+                if enabled {
+                    if !text.hasSuffix("/") {
+                        text += "/"
                     }
                 } else {
-                    if newdata.localcatalog.hasSuffix("/") {
-                        newdata.localcatalog.removeLast()
+                    if text.hasSuffix("/") {
+                        text.removeLast()
                     }
                 }
+
+                value.wrappedValue = text
             }
+        ))
     }
 
     var pickerselecttypeoftask: some View {
@@ -220,7 +228,6 @@ struct TaskForm: View {
             Form {
                 pickerselecttypeoftask
 
-                trailingslash
                 synchronizeID
                 catalogSectionView
                 remoteuserandserver
@@ -228,7 +235,6 @@ struct TaskForm: View {
             .formStyle(.grouped)
         case .update:
             Form {
-                trailingslash
                 synchronizeID
                 catalogSectionView
                 remoteuserandserver

--- a/RsyncUI/Views/Quicktask/extensionQuickTaskView.swift
+++ b/RsyncUI/Views/Quicktask/extensionQuickTaskView.swift
@@ -41,7 +41,6 @@ extension QuicktaskView {
 
     func resetForm() {
         selectedrsynccommand = .synchronize
-        trailingslashoptions = true
         dryrun = true
         catalogorfile = true
         localcatalog = ""
@@ -56,7 +55,6 @@ extension QuicktaskView {
         let getdata = NewTask(selectedrsynccommand.rawValue,
                               localcatalog,
                               remotecatalog,
-                              trailingslashoptions,
                               remoteuser,
                               remoteserver,
                               "")


### PR DESCRIPTION
This PR removes `trailingslash` from `ObservableAddConfigurations`.
It doesn't need to be stored in a variable, the toggle can be bound to the actual value.
This avoids the toggle being out of sync with the actual value while keeping the current functionality as-is.