### PR TITLE
`Parameters` tab content redesign

### DIFF
--- a/RsyncUI/Views/InspectorViews/RsyncParameters/EditRsyncParameter.swift
+++ b/RsyncUI/Views/InspectorViews/RsyncParameters/EditRsyncParameter.swift
@@ -10,7 +10,6 @@ import SwiftUI
 struct EditRsyncParameter: View {
     @State private var selectedparameter = EnumRsyncArguments.add
     var myvalue: Binding<String>
-    var mywidth: CGFloat?
 
     var body: some View {
         HStack {
@@ -19,13 +18,10 @@ struct EditRsyncParameter: View {
                     .tag($0)
                 }
             }
-            .pickerStyle(MenuPickerStyle())
-            .frame(width: 120)
+            .labelsHidden()
+            .pickerStyle(.menu)
 
             TextField("", text: myvalue)
-                .textFieldStyle(RoundedBorderTextFieldStyle())
-                .frame(width: mywidth)
-                .lineLimit(1)
                 .onChange(of: selectedparameter) {
                     guard selectedparameter.rawValue != EnumRsyncArguments.add.rawValue else { return }
                     let argument = selectedparameter.rawValue
@@ -38,11 +34,11 @@ struct EditRsyncParameter: View {
                         selectedparameter = EnumRsyncArguments.add
                     }
                 }
+                .frame(maxWidth: .infinity)
         }
     }
 
-    init(_ width: CGFloat, _ value: Binding<String>) {
-        mywidth = width
+    init(_ value: Binding<String>) {
         myvalue = value
     }
 

--- a/RsyncUI/Views/InspectorViews/RsyncParameters/RsyncParametersView.swift
+++ b/RsyncUI/Views/InspectorViews/RsyncParameters/RsyncParametersView.swift
@@ -20,99 +20,65 @@ struct RsyncParametersView: View {
     @State var presentarguments: Bool = false
 
     var body: some View {
-        VStack(alignment: .leading, spacing: 12) {
-            addupdateButton
-
-            VStack(alignment: .leading, spacing: 8) {
-                EditRsyncParameter(350, $parameters.parameter8)
+        Form {
+            Section("Parameters") {
+                EditRsyncParameter($parameters.parameter8)
                     .onChange(of: parameters.parameter8) { parameters.configuration?.parameter8 = parameters.parameter8 }
-                EditRsyncParameter(350, $parameters.parameter9)
+                EditRsyncParameter($parameters.parameter9)
                     .onChange(of: parameters.parameter9) { parameters.configuration?.parameter9 = parameters.parameter9 }
-                EditRsyncParameter(350, $parameters.parameter10)
+                EditRsyncParameter($parameters.parameter10)
                     .onChange(of: parameters.parameter10) { parameters.configuration?.parameter10 = parameters.parameter10 }
-                EditRsyncParameter(350, $parameters.parameter11)
+                EditRsyncParameter($parameters.parameter11)
                     .onChange(of: parameters.parameter11) { parameters.configuration?.parameter11 = parameters.parameter11 }
-                EditRsyncParameter(350, $parameters.parameter12)
+                EditRsyncParameter($parameters.parameter12)
                     .onChange(of: parameters.parameter12) { parameters.configuration?.parameter12 = parameters.parameter12 }
-                EditRsyncParameter(350, $parameters.parameter13)
+                EditRsyncParameter($parameters.parameter13)
                     .onChange(of: parameters.parameter13) { parameters.configuration?.parameter13 = parameters.parameter13 }
-                EditRsyncParameter(350, $parameters.parameter14)
+                EditRsyncParameter($parameters.parameter14)
                     .onChange(of: parameters.parameter14) { parameters.configuration?.parameter14 = parameters.parameter14 }
             }
 
-            VStack(alignment: .leading, spacing: 8) {
-                Text("Task specific SSH parameter").font(.headline)
+            Section("SSH") {
+                TextField("SSH keypath and identityfile", text: $parameters.sshkeypathandidentityfile)
+                TextField("SSH port", text: $parameters.sshport)
+            }
+
+            Section("Backup") {
+                Toggle("--backup Parameter", isOn: $backup)
+                    .toggleStyle(.switch)
+                    .onChange(of: backup) {
+                        guard !selecteduuids.isEmpty else {
+                            backup = false
+                            return
+                        }
+                        parameters.setbackup()
+                    }
+            }
+
+            Section {
                 HStack {
-                    setsshpath(path: $parameters.sshkeypathandidentityfile,
-                               placeholder: "set SSH keypath and identityfile",
-                               selectedValue: parameters.sshkeypathandidentityfile)
-                    sshportfield(port: $parameters.sshport,
-                                 placeholder: "set SSH port",
-                                 selectedValue: parameters.sshport)
-                }
-            }
-
-            let isDeletePresent = selectedconfig?.parameter4 == "--delete"
-            let headerText = isDeletePresent ? "Remove --delete parameter" : "Add --delete parameter"
-
-            HStack {
-                VStack(alignment: .leading, spacing: 12) {
-                    HStack {
-                        // 1. The Frame Title
-                        Text("Danger Zone")
-                            .font(.headline)
-                            .foregroundStyle(.red)
-
-                        Text(headerText)
-                            .font(.headline)
-                            .foregroundStyle(isDeletePresent ? Color(.red) : Color(.blue))
-                    }
-
-                    Divider()
-                        .background(Color.red.opacity(0.5))
-
-                    HStack {
-                        Toggle("--delete", isOn: $parameters.adddelete)
-                            .toggleStyle(.switch)
-                            .onChange(of: parameters.adddelete) { parameters.adddelete(parameters.adddelete) }
-                            .disabled(selecteduuids.isEmpty)
-
-                        // 3. The New Website Button
+                    Toggle(isOn: $parameters.adddelete, label: {
                         Link(destination: URL(string: "https://rsyncui.netlify.app/docs/getting-started/important/")!) {
-                            Text("Info")
-                                .frame(maxWidth: .infinity)
-                                .padding(.vertical, 8)
-                                .background(Color.red)
-                                .foregroundStyle(.white)
-                                .clipShape(.rect(cornerRadius: 8))
+                            Text("--delete Parameter")
+                            Image(systemName: "info.circle")
                         }
-                        .padding(.top, 4)
-                    }
-                }
-                .padding() // Adds space inside the border
-                .background(Color.red.opacity(0.05)) // Optional: Light red background tint
-                .clipShape(.rect(cornerRadius: 10)) // Rounds the corners of the frame
-                .overlay(
-                    RoundedRectangle(cornerRadius: 10)
-                        .stroke(Color.red, lineWidth: 2) // The red border
-                )
-                .padding() // Outer margin
+                        .foregroundStyle(.red)
 
-                VStack(alignment: .leading, spacing: 8) {
-                    Text("Append Backup parameter")
-                        .font(.headline)
-                    Toggle("Backup", isOn: $backup)
-                        .toggleStyle(.switch)
-                        .onChange(of: backup) {
-                            guard !selecteduuids.isEmpty else {
-                                backup = false
-                                return
-                            }
-                            parameters.setbackup()
-                        }
+                    })
+                    .toggleStyle(.switch)
+                    .onChange(of: parameters.adddelete) { parameters.adddelete(parameters.adddelete) }
+                    .disabled(selecteduuids.isEmpty)
+                    .tint(.red)
                 }
             }
+            header: {
+                Text("Danger Zone")
+                    .foregroundStyle(.red)
+            }
+
+            updateButton
         }
+        .formStyle(.grouped)
         .onAppear { handleSelectionChange() }
         .onChange(of: rsyncUIdata.profile) {
             selectedconfig = nil

--- a/RsyncUI/Views/InspectorViews/RsyncParameters/extensionRsyncParametersView.swift
+++ b/RsyncUI/Views/InspectorViews/RsyncParameters/extensionRsyncParametersView.swift
@@ -37,23 +37,13 @@ extension RsyncParametersView {
 // MARK: - Buttons
 
 extension RsyncParametersView {
-    var addupdateButton: some View {
-        if notifydataisupdated {
-            Button("Update", systemImage: "arrow.down") {
-                saveRsyncParameters()
-                selecteduuids.removeAll()
-            }
-            .help("Update parameters")
-            .disabled(selectedconfig == nil)
-            .padding(.bottom, 10)
-        } else {
-            Button("Add", systemImage: "plus") {
-                saveRsyncParameters()
-            }
-            .help("Save parameters")
-            .disabled(selectedconfig == nil)
-            .padding(.bottom, 10)
+    var updateButton: some View {
+        Button("Update", systemImage: "arrow.down") {
+            saveRsyncParameters()
+            selecteduuids.removeAll()
         }
+        .help("Update parameters")
+        .disabled(selectedconfig == nil)
     }
 }
 
@@ -159,37 +149,5 @@ extension RsyncParametersView {
 
         // Check existence
         return FileManager.default.fileExists(atPath: expandedPath)
-    }
-}
-
-// MARK: - State Properties
-
-extension RsyncParametersView {
-    var notifydataisupdated: Bool {
-        var sshport = ""
-        var sshkeypathandidentityfile = ""
-
-        if let configsshport = selectedconfig?.sshport, configsshport != -1 {
-            sshport = String(configsshport)
-        }
-        if let configurationsshcreatekey = selectedconfig?.sshkeypathandidentityfile {
-            sshkeypathandidentityfile = configurationsshcreatekey
-        }
-        guard let selectedconfig else { return false }
-        if parameters.parameter8 != (selectedconfig.parameter8 ?? "") ||
-            parameters.parameter9 != (selectedconfig.parameter9 ?? "") ||
-            parameters.parameter10 != (selectedconfig.parameter10 ?? "") ||
-            parameters.parameter11 != (selectedconfig.parameter11 ?? "") ||
-            parameters.parameter12 != (selectedconfig.parameter12 ?? "") ||
-            parameters.parameter13 != (selectedconfig.parameter13 ?? "") ||
-            parameters.parameter14 != (selectedconfig.parameter14 ?? "") ||
-            parameters.parameter14 != (selectedconfig.parameter14 ?? "") ||
-            parameters.adddelete == (selectedconfig.parameter4 == nil) ||
-            parameters.sshport != String(sshport) ||
-            parameters.sshkeypathandidentityfile != sshkeypathandidentityfile
-        {
-            return true
-        }
-        return false
     }
 }


### PR DESCRIPTION
This PR is a proposal for a redesign for the `Parameters` tab content.
It uses the same grouped form style as in the `Edit` tab content and rearranges some sections and content in a more logical way.

Before: 
<img width="1645" height="1050" alt="Bildschirmfoto 2026-07-18 um 00 10 24" src="https://github.com/user-attachments/assets/2541728a-b1a5-4bda-98af-dd1806c1cd53" />


After:
<img width="1645" height="1050" alt="Bildschirmfoto 2026-07-18 um 00 09 49" src="https://github.com/user-attachments/assets/4416e7c9-8b4b-4dcc-bc3f-b064461a519b" />
